### PR TITLE
create board entity

### DIFF
--- a/application/src/main/kotlin/sampe/jpa/SampleApplication.kt
+++ b/application/src/main/kotlin/sampe/jpa/SampleApplication.kt
@@ -2,7 +2,9 @@ package sampe.jpa
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
+@EnableJpaAuditing
 @SpringBootApplication
 open class SampleApplication
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ subprojects {
 
 	dependencies {
 		implementation("org.springframework.boot:spring-boot-starter-web")
+		implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 		annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 		implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 		implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -82,7 +83,6 @@ project(":domain") {
 	bootJar.enabled = false
 	jar.enabled = true
 	dependencies {
-		implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 		runtimeOnly("com.h2database:h2")
 		runtimeOnly("mysql:mysql-connector-java")
 	}

--- a/domain/src/main/kotlin/sample/jpa/CreatedAtEntity.kt
+++ b/domain/src/main/kotlin/sample/jpa/CreatedAtEntity.kt
@@ -1,0 +1,14 @@
+package sample.jpa
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class CreatedAtEntity {
+    @CreatedDate
+    var createdAt: LocalDateTime? = null
+}

--- a/domain/src/main/kotlin/sample/jpa/board/exception/BoardNotExistException.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/exception/BoardNotExistException.kt
@@ -1,0 +1,4 @@
+package sample.jpa.board.exception
+
+class BoardNotFoundException {
+}

--- a/domain/src/main/kotlin/sample/jpa/board/exception/BoardNotExistException.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/exception/BoardNotExistException.kt
@@ -1,4 +1,3 @@
 package sample.jpa.board.exception
 
-class BoardNotFoundException {
-}
+class BoardNotExistException : RuntimeException("존재하지 않는 게시판입니다.")

--- a/domain/src/main/kotlin/sample/jpa/board/exception/BoardTitleAlreadyExistException.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/exception/BoardTitleAlreadyExistException.kt
@@ -1,4 +1,3 @@
 package sample.jpa.board.exception
 
-class BoardTitleAlreadyExistException {
-}
+class BoardTitleAlreadyExistException : RuntimeException("이미 존재하는 게시판 이름입니다.")

--- a/domain/src/main/kotlin/sample/jpa/board/exception/BoardTitleAlreadyExistException.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/exception/BoardTitleAlreadyExistException.kt
@@ -1,0 +1,4 @@
+package sample.jpa.board.exception
+
+class BoardTitleAlreadyExistException {
+}

--- a/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
@@ -1,0 +1,4 @@
+package sample.jpa.board.model.entity
+
+class Board {
+}

--- a/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
@@ -9,7 +9,6 @@ data class Board (
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "board_id", nullable = false)
     val id: Long? = null,
 
     @Column(name = "board_type", nullable = false)

--- a/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
@@ -1,4 +1,24 @@
 package sample.jpa.board.model.entity
 
-class Board {
-}
+import sample.jpa.board.model.enum.BoardType
+import java.time.LocalDateTime
+import javax.persistence.*
+
+@Entity
+data class Board (
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "boardId", nullable = false)
+    val id: Long? = null,
+
+    @Column(name = "boardType", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val type: BoardType,
+
+    @Column(name = "boardTitle", length = 100, nullable = false)
+    val title: String,
+
+    @Column(updatable = false, nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/entity/Board.kt
@@ -1,7 +1,7 @@
 package sample.jpa.board.model.entity
 
+import sample.jpa.CreatedAtEntity
 import sample.jpa.board.model.enum.BoardType
-import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
@@ -9,16 +9,14 @@ data class Board (
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "boardId", nullable = false)
+    @Column(name = "board_id", nullable = false)
     val id: Long? = null,
 
-    @Column(name = "boardType", nullable = false)
+    @Column(name = "board_type", nullable = false)
     @Enumerated(EnumType.STRING)
     val type: BoardType,
 
-    @Column(name = "boardTitle", length = 100, nullable = false)
+    @Column(name = "board_title", length = 100, nullable = false)
     val title: String,
 
-    @Column(updatable = false, nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now()
-)
+) : CreatedAtEntity()

--- a/domain/src/main/kotlin/sample/jpa/board/model/enum/BoardType.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/enum/BoardType.kt
@@ -1,0 +1,4 @@
+package sample.jpa.board.model.enum
+
+class BoardType {
+}

--- a/domain/src/main/kotlin/sample/jpa/board/model/enum/BoardType.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/enum/BoardType.kt
@@ -1,4 +1,7 @@
 package sample.jpa.board.model.enum
 
-class BoardType {
+enum class BoardType {
+    BOARDTYPE_ONE,
+    BOARDTYPE_TWO,
+    BOARDTYPE_THREE
 }

--- a/domain/src/main/kotlin/sample/jpa/board/model/repository/BoardRepository.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/repository/BoardRepository.kt
@@ -1,0 +1,4 @@
+package sample.jpa.board.model.repository
+
+class BoardRepository {
+}

--- a/domain/src/main/kotlin/sample/jpa/board/model/repository/BoardRepository.kt
+++ b/domain/src/main/kotlin/sample/jpa/board/model/repository/BoardRepository.kt
@@ -1,4 +1,10 @@
 package sample.jpa.board.model.repository
 
-class BoardRepository {
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import sample.jpa.board.model.entity.Board
+
+@Repository
+interface BoardRepository: JpaRepository<Board, Long> {
+    fun existsByBoardTitle(title: String): Boolean
 }


### PR DESCRIPTION
## 변경점
1. 게시판의 `exception`, `entity`, `repository` 작성
2. 게시판 유형(type)을 enum 클래스로 작성
## 궁금증
작성하면서 고민했던 것 2가지가 있는데요,
1. `createAt`이나, `updateAt` 등의 코드가 계속 쓰일 거 같더라고요. 찾아보니 중복을 피하려고 JPA Auditing이라는 기능을 사용해서 `BaseTimeEntity` 라는 엔티티를 만들어 공통으로 관리하는 해결책이 있던데, 이 방법에 대해서 어떻게 생각하시는 지 궁금합니다.
2. enum 클래스에서 게시판 유형 이름을 그냥 one, two, three로 지정했는데, 이대로도 괜찮을까요, 혹시 더 나은 작명이 있을까요?
+) enum클래스 말고 더 좋은 관리방법이 있는지도 궁금합니다!

혼자 고민해서 해결하기엔 어려워보여, PR을 우선 올린 후 리뷰 받으며 보완해보려 합니다!