### PR TITLE
Feat/advertisement

### DIFF
--- a/domain/src/main/kotlin/sample/jpa/advertisement/model/entity/Advertisement.kt
+++ b/domain/src/main/kotlin/sample/jpa/advertisement/model/entity/Advertisement.kt
@@ -1,0 +1,25 @@
+package sample.jpa.advertisement.model.entity
+
+import sample.jpa.CreatedUpdatedAtEntity
+import sample.jpa.common.enum.Category
+import sample.jpa.interest.model.entity.Interest
+import javax.persistence.*
+
+@Entity
+class Advertisement(
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id : Long? = null,
+
+    @Lob
+    @Column(name="content", nullable = false)
+    var content : String,
+
+    @Column(name="photo", nullable = true)
+    var photoUrl : String,
+
+    @Column(name="interest", nullable = false)
+    @Enumerated(EnumType.STRING)
+    var category : Category
+
+): CreatedUpdatedAtEntity(){}

--- a/domain/src/main/kotlin/sample/jpa/advertisement/model/entity/Advertisement.kt
+++ b/domain/src/main/kotlin/sample/jpa/advertisement/model/entity/Advertisement.kt
@@ -16,7 +16,7 @@ class Advertisement(
     var content : String,
 
     @Column(name="photo", nullable = true)
-    var photoUrl : String,
+    var photoUrl : String? = null,
 
     @Column(name="category", nullable = false)
     @Enumerated(EnumType.STRING)

--- a/domain/src/main/kotlin/sample/jpa/advertisement/model/entity/Advertisement.kt
+++ b/domain/src/main/kotlin/sample/jpa/advertisement/model/entity/Advertisement.kt
@@ -18,7 +18,7 @@ class Advertisement(
     @Column(name="photo", nullable = true)
     var photoUrl : String,
 
-    @Column(name="interest", nullable = false)
+    @Column(name="category", nullable = false)
     @Enumerated(EnumType.STRING)
     var category : Category
 

--- a/domain/src/main/kotlin/sample/jpa/advertisement/model/repository/AdvertisementRepository.kt
+++ b/domain/src/main/kotlin/sample/jpa/advertisement/model/repository/AdvertisementRepository.kt
@@ -1,0 +1,7 @@
+package sample.jpa.advertisement.model.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import sample.jpa.advertisement.model.entity.Advertisement
+
+interface AdvertisementRepository: JpaRepository<Advertisement, Long> {
+}

--- a/domain/src/main/kotlin/sample/jpa/common/enum/Category.kt
+++ b/domain/src/main/kotlin/sample/jpa/common/enum/Category.kt
@@ -6,5 +6,6 @@ enum class Category {
     RELATIONSHIP,
     HEALTH,
     BOOK,
-    FASHION
+    FASHION,
+    ETC
 }

--- a/domain/src/main/kotlin/sample/jpa/common/enum/Category.kt
+++ b/domain/src/main/kotlin/sample/jpa/common/enum/Category.kt
@@ -1,0 +1,10 @@
+package sample.jpa.common.enum
+
+enum class Category {
+    SPORTS,
+    PROGRAMMING,
+    RELATIONSHIP,
+    HEALTH,
+    BOOK,
+    FASHION
+}

--- a/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
@@ -1,0 +1,16 @@
+package sample.jpa.interest.model.entity
+
+import sample.jpa.common.enum.Category
+import javax.persistence.*
+
+@Entity
+class Interest(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long =0,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    val category: Category
+)

--- a/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
@@ -9,12 +9,12 @@ class Interest(
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long =0,
+    val id: Long = 0,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)
     var category: Category,
 
     @OneToMany(mappedBy = "interest")
-    var userInterest: MutableList<UserInterest>?=null
+    var userInterest: MutableList<UserInterest> = mutableListOf<UserInterest>()
 ): CreatedUpdatedAtEntity(){}

--- a/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
@@ -13,8 +13,8 @@ class Interest(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)
-    val category: Category,
+    var category: Category,
 
     @OneToMany(mappedBy = "interest")
-    val userAndInterest: MutableList<UserAndInterest>?=null
+    var userInterest: MutableList<UserInterest>?=null
 ): CreatedUpdatedAtEntity(){}

--- a/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/entity/Interest.kt
@@ -1,5 +1,6 @@
 package sample.jpa.interest.model.entity
 
+import sample.jpa.CreatedUpdatedAtEntity
 import sample.jpa.common.enum.Category
 import javax.persistence.*
 
@@ -12,5 +13,8 @@ class Interest(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)
-    val category: Category
-)
+    val category: Category,
+
+    @OneToMany(mappedBy = "interest")
+    val userAndInterest: MutableList<UserAndInterest>?=null
+): CreatedUpdatedAtEntity(){}

--- a/domain/src/main/kotlin/sample/jpa/interest/model/entity/UserAndInterest.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/entity/UserAndInterest.kt
@@ -1,0 +1,21 @@
+package sample.jpa.interest.model.entity
+
+import sample.jpa.CreatedUpdatedAtEntity
+import sample.jpa.users.model.entity.User
+import javax.persistence.*
+
+@Entity
+class UserAndInterest (
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id : Long? = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user : User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interest_id", nullable= false)
+    val interest : Interest
+
+):CreatedUpdatedAtEntity(){}

--- a/domain/src/main/kotlin/sample/jpa/interest/model/entity/UserInterest.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/entity/UserInterest.kt
@@ -5,7 +5,7 @@ import sample.jpa.users.model.entity.User
 import javax.persistence.*
 
 @Entity
-class UserAndInterest (
+class UserInterest (
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id : Long? = 0,

--- a/domain/src/main/kotlin/sample/jpa/interest/model/repository/InterestRepository.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/repository/InterestRepository.kt
@@ -1,0 +1,7 @@
+package sample.jpa.interest.model.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import sample.jpa.interest.model.entity.Interest
+
+interface InterestRepository:JpaRepository<Interest, Long> {
+}

--- a/domain/src/main/kotlin/sample/jpa/interest/model/repository/UserAndInterestRepository.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/repository/UserAndInterestRepository.kt
@@ -1,8 +1,8 @@
 package sample.jpa.interest.model.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import sample.jpa.interest.model.entity.UserAndInterest
+import sample.jpa.interest.model.entity.UserInterest
 
 
-interface UserAndInterestRepository:JpaRepository<UserAndInterest,Long> {
+interface UserAndInterestRepository:JpaRepository<UserInterest,Long> {
 }

--- a/domain/src/main/kotlin/sample/jpa/interest/model/repository/UserAndInterestRepository.kt
+++ b/domain/src/main/kotlin/sample/jpa/interest/model/repository/UserAndInterestRepository.kt
@@ -1,0 +1,8 @@
+package sample.jpa.interest.model.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import sample.jpa.interest.model.entity.UserAndInterest
+
+
+interface UserAndInterestRepository:JpaRepository<UserAndInterest,Long> {
+}

--- a/domain/src/main/kotlin/sample/jpa/users/model/entity/User.kt
+++ b/domain/src/main/kotlin/sample/jpa/users/model/entity/User.kt
@@ -1,7 +1,6 @@
 package sample.jpa.users.model.entity
 
-import sample.jpa.interest.model.entity.UserAndInterest
-import sample.jpa.post.model.entity.Post
+import sample.jpa.interest.model.entity.UserInterest
 import javax.persistence.*
 
 @Entity
@@ -21,6 +20,6 @@ class User (
     var password: String,
 
     @OneToMany(mappedBy = "user")
-    val userAndInterest: MutableList<UserAndInterest>?=null
+    var userInterest: MutableList<UserInterest>?=null
 
 )

--- a/domain/src/main/kotlin/sample/jpa/users/model/entity/User.kt
+++ b/domain/src/main/kotlin/sample/jpa/users/model/entity/User.kt
@@ -1,5 +1,6 @@
 package sample.jpa.users.model.entity
 
+import sample.jpa.interest.model.entity.UserAndInterest
 import sample.jpa.post.model.entity.Post
 import javax.persistence.*
 
@@ -18,5 +19,8 @@ class User (
 
     @Column(length = 100, nullable = false)
     var password: String,
+
+    @OneToMany(mappedBy = "user")
+    val userAndInterest: MutableList<UserAndInterest>?=null
 
 )

--- a/domain/src/main/kotlin/sample/jpa/users/model/entity/User.kt
+++ b/domain/src/main/kotlin/sample/jpa/users/model/entity/User.kt
@@ -20,6 +20,6 @@ class User (
     var password: String,
 
     @OneToMany(mappedBy = "user")
-    var userInterest: MutableList<UserInterest>?=null
+    var userInterest: MutableList<UserInterest> = mutableListOf<UserInterest>()
 
 )


### PR DESCRIPTION
1. User는 자신의 흥미있는분야(interest)를 등록할 수 있습니다.
2. Interest(흥미 분야)의 category는 enum으로 하였습니다.(ex)sports, health..)
3. User가 흥미있어하는 분야의 광고를 보여줄 예정입니다.
4. Advertise는 category별로 분류됩니다.(category 컬럼이 있습니다)

5. User는 다수의 Interest를 가질 수 있으며, 반대로 Interest역시 다수의 User와 관계를 맺을 수 있습니다(가질 수 있습니다)
-> 이 이유 때문에 UserAndInterest 테이블(Entity)를 만들었습니다. Entity를 따로 만들지 않고 Enum으로만 해결하는 방법을 고민했지만 찾지 못하였습니다. 유저의 흥미분야에 맞는 광고를 보여줄 수 있는 더 좋은 방법이 생각나신다면 공유 부탁드립니다.

